### PR TITLE
Adds requirements file needed for Mybinder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+matplotlib
+seaborn


### PR DESCRIPTION
Adding this presumably shouldn't hurt anything in this lesson, but would allow this repo (and thus the notebook learners just worked through) to be used as the example for sharing live notebooks in Mybinder.org. (Also see Reproducible-Science-Curriculum/sharing-RR-Jupyter#8 for how the currently used example is broken.)